### PR TITLE
fix: add ExistingFilePolicy.CREATE_NEW to all save_static_file calls to prevent race conditions

### DIFF
--- a/griptape_nodes_sam3_library/griptape-nodes-library.json
+++ b/griptape_nodes_sam3_library/griptape-nodes-library.json
@@ -5,8 +5,8 @@
   "metadata": {
     "author": "griptape-ai",
     "description": "SAM3 (Segment Anything with Concepts) integration for Griptape Nodes - AI-powered image and video segmentation with text prompts",
-    "library_version": "0.2.1",
-    "engine_version": "0.60.2",
+    "library_version": "0.2.2",
+    "engine_version": "0.66.0",
     "tags": [
       "Griptape",
       "AI",

--- a/griptape_nodes_sam3_library/sam3_segment_image.py
+++ b/griptape_nodes_sam3_library/sam3_segment_image.py
@@ -10,6 +10,7 @@ from griptape.artifacts import ImageArtifact, ImageUrlArtifact
 from PIL import Image
 
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
@@ -331,7 +332,7 @@ class Sam3SegmentImage(SuccessFailureNode):
         image.save(buffer, format="PNG")
         image_bytes = buffer.getvalue()
         filename = f"{uuid.uuid4()}.png"
-        url = GriptapeNodes.StaticFilesManager().save_static_file(image_bytes, filename)
+        url = GriptapeNodes.StaticFilesManager().save_static_file(image_bytes, filename, ExistingFilePolicy.CREATE_NEW)
         return ImageUrlArtifact(url)
 
     def _mask_to_image(self, mask: Any) -> Image.Image:

--- a/griptape_nodes_sam3_library/sam3_segment_video.py
+++ b/griptape_nodes_sam3_library/sam3_segment_video.py
@@ -12,6 +12,7 @@ from PIL import Image
 from griptape.artifacts import VideoUrlArtifact
 
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
@@ -593,5 +594,5 @@ class Sam3SegmentVideo(SuccessFailureNode):
 
         video_bytes = video_path.read_bytes()
         filename = f"{uuid.uuid4()}.mp4"
-        url = GriptapeNodes.StaticFilesManager().save_static_file(video_bytes, filename)
+        url = GriptapeNodes.StaticFilesManager().save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
         return VideoUrlArtifact(url)


### PR DESCRIPTION
## Important!!!
Do not merge until https://github.com/griptape-ai/griptape-nodes/pull/3374 has made to a stable release. This requires a new parameter to be available to `StaticFilesManager().save_static_file`

Fixes https://github.com/griptape-ai/griptape-nodes/issues/3373