### PR TITLE
fix: move SAM3 nodes to image/video segmentation categories

### DIFF
--- a/griptape_nodes_sam3_library/griptape-nodes-library.json
+++ b/griptape_nodes_sam3_library/griptape-nodes-library.json
@@ -23,18 +23,23 @@
         "torchaudio>=2.7.0",
         "static_ffmpeg>=2.13.0"
       ],
-      "pip_install_flags": [
-        "--preview",
-        "--torch-backend=auto"
-      ]
+      "pip_install_flags": ["--preview", "--torch-backend=auto"]
     }
   },
   "categories": [
     {
-      "sam3": {
+      "image/segmentation": {
         "color": "border-purple-500",
-        "title": "SAM3",
-        "description": "SAM3 image and video segmentation nodes",
+        "title": "Image/Segmentation",
+        "description": "Image segmentation nodes",
+        "icon": "layers"
+      }
+    },
+    {
+      "video/segmentation": {
+        "color": "border-pink-500",
+        "title": "Video/Segmentation",
+        "description": "Video segmentation nodes",
         "icon": "layers"
       }
     }
@@ -44,7 +49,7 @@
       "class_name": "Sam3SegmentImage",
       "file_path": "sam3_segment_image.py",
       "metadata": {
-        "category": "sam3",
+        "category": "image/segmentation",
         "description": "Segment objects in images using SAM3 with text prompts",
         "display_name": "SAM3 Segment Image"
       }
@@ -53,7 +58,7 @@
       "class_name": "Sam3SegmentVideo",
       "file_path": "sam3_segment_video.py",
       "metadata": {
-        "category": "sam3",
+        "category": "video/segmentation",
         "description": "Segment objects in videos using SAM3 with text prompts",
         "display_name": "SAM3 Segment Video"
       }


### PR DESCRIPTION
## Summary

This PR moves the SAM3 nodes from their own dedicated `sam3` category to the appropriate subcategories under `image` and `video`:

- `Sam3SegmentImage` → `image/segmentation`
- `Sam3SegmentVideo` → `video/segmentation`

## Rationale

When adding nodes to a library, we should **place them into existing categories in the sidebar hierarchy** rather than creating new categories—especially top-level categories.

Creating a dedicated top-level category for every library or tool leads to:
- A cluttered and fragmented sidebar
- Inconsistent user experience when looking for related functionality
- Difficulty discovering nodes that serve similar purposes

By placing segmentation nodes under `image/` and `video/`, users can find all image-related or video-related functionality in one place, regardless of the underlying implementation (SAM3, or any future segmentation tools).

## Changes

- Replaced the `sam3` category with `image/segmentation` and `video/segmentation` categories
- Updated node metadata to reference the new category paths