### PR TITLE
Fix video mask count mismatch when objects not in first frame

### DIFF
--- a/griptape_nodes_sam3_library/sam3_segment_video.py
+++ b/griptape_nodes_sam3_library/sam3_segment_video.py
@@ -471,7 +471,13 @@ class Sam3SegmentVideo(SuccessFailureNode):
         return outputs_per_frame
 
     def _create_masked_frames_multi(
-        self, input_dir: Path, outputs_per_frame: dict, composite_dir: Path, temp_dir: Path, opacity: float, num_objects: int
+        self,
+        input_dir: Path,
+        outputs_per_frame: dict,
+        composite_dir: Path,
+        temp_dir: Path,
+        opacity: float,
+        num_objects: int,
     ) -> list[Path]:
         """Create individual mask frame directories and composite frames.
 

--- a/griptape_nodes_sam3_library/sam3_segment_video.py
+++ b/griptape_nodes_sam3_library/sam3_segment_video.py
@@ -249,6 +249,7 @@ class Sam3SegmentVideo(SuccessFailureNode):
                 composite_frames_dir,
                 temp_dir,
                 mask_opacity,
+                num_objects,
             )
 
             # Encode individual mask videos (directly to H.264)
@@ -470,7 +471,7 @@ class Sam3SegmentVideo(SuccessFailureNode):
         return outputs_per_frame
 
     def _create_masked_frames_multi(
-        self, input_dir: Path, outputs_per_frame: dict, composite_dir: Path, temp_dir: Path, opacity: float
+        self, input_dir: Path, outputs_per_frame: dict, composite_dir: Path, temp_dir: Path, opacity: float, num_objects: int
     ) -> list[Path]:
         """Create individual mask frame directories and composite frames.
 
@@ -491,23 +492,8 @@ class Sam3SegmentVideo(SuccessFailureNode):
             (128, 0, 255),  # Purple
         ]
 
-        # Determine number of objects from first frame with masks
-        num_objects = 0
-        for outputs in outputs_per_frame.values():
-            binary_masks = outputs.get("out_binary_masks")
-            if binary_masks is not None:
-                if hasattr(binary_masks, "cpu"):
-                    binary_masks = binary_masks.cpu().numpy()
-                elif not isinstance(binary_masks, np.ndarray):
-                    binary_masks = np.array(binary_masks)
-                if binary_masks.ndim == 2:
-                    num_objects = 1
-                elif binary_masks.ndim == 3:
-                    num_objects = binary_masks.shape[0]
-                break
-
         if num_objects == 0:
-            logger.warning("No masks found in any frame")
+            logger.warning("No objects found during initial prompt")
             return []
 
         # Create directories for each object's mask frames


### PR DESCRIPTION
## Summary
- Fixes bug where number of output mask videos doesn't match number of detected objects
- Root cause: code was re-determining object count from first frame's masks instead of using initial prompt response
- Objects not visible in first processed frame were being ignored

## Details
When segmenting video with text prompts, the initial prompt may detect N objects, but not all objects necessarily appear in the first processed frame. The code was re-determining `num_objects` by inspecting the first frame's masks, which could be less than the actual number of detected objects.

**Before:** 
- Initial prompt finds 5 objects
- First frame only contains 4 objects
- Only 4 mask video directories created
- 5th object ignored throughout video

**After:**
- Initial prompt finds 5 objects  
- Pass that count directly to `_create_masked_frames_multi`
- All 5 mask video directories created
- All detected objects properly tracked

## Test plan
- [ ] Run SAM3 video segmentation with text prompt that detects multiple objects
- [ ] Verify log shows "Found N object(s) matching prompt"
- [ ] Verify exactly N mask videos are created in output
- [ ] Verify composite video shows all N objects with different colors
- [ ] Test with video where not all objects appear in first frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)